### PR TITLE
Fixes the spelling of 'password' on the forgotten password page.

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -10,7 +10,7 @@
       p.login-box-msg.text-red = alert
     - if notice
       p.login-box-msg.text-yellow = noitce
-    h3 Forgot your passowrd?
+    h3 Forgot your password?
     = form_for resource, as: resource_name, url: admin_password_path(resource),
       html: { method: :post } do |f| %
 


### PR DESCRIPTION
Found this over the weekend. Figured it'd be an easy first PR. :)

I didn't see an open issue for this, but opening one just to close it seemed like overkill. Let me know if you'd like me to do that anyway for bookkeeping reasons.