### PR TITLE
Route user correctly based on sign_in status

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,20 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  after_filter :store_action
-
-  private
-
-  def after_sign_out_path_for(_)
-    game_control_root_path
-  end
-
-
-  def store_action
-    return unless request.get?
-    if (request.path.end_with?("/sign_in") &&
-        !request.xhr?) # don't store ajax calls
-      store_location_for(:admin, game_control_root_path)
-    end
-  end
 end

--- a/app/controllers/game_control/sessions_controller.rb
+++ b/app/controllers/game_control/sessions_controller.rb
@@ -1,0 +1,13 @@
+class GameControl::SessionsController < Devise::SessionsController
+  layout 'devise'
+
+  private
+
+  def after_sign_in_path_for(_)
+    stored_location_for(resource_name) || game_control_root_path
+  end
+
+  def after_sign_out_path_for(_)
+    game_control_root_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,8 @@ Rails.application.routes.draw do
   end
 
   devise_for :admins, path: :game_control,
-                      controllers: { invitations: "game_control/invitations" }
+                      controllers: { sessions: 'game_control/sessions',
+                                     invitations: 'game_control/invitations' }
 
   namespace :game_control do
     root 'dashboard#index'


### PR DESCRIPTION
Fixes #70

What?
======
Added `GameControl::SessionsController` to overwrite the default paths
after sign in and sign out.

Removed previous fix that fixed half the problem.


Test
====
1. While not logged in visit `/game_control/sign_in` and login. You should be redirected to `/game_control`.
1. Visit `/game_control/sign_in`. You should be redirected to `/game_control`.
1. While not logged in visit `/game_control/pages`. You should be redirected to the sign_in page. Login. You should be redirected to `/game_control/pages`.
