### PR TITLE
City display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ The `doc/` subfolder contains several useful resources:
 
 - [`CONTRIBUTING.md`](doc/CONTRIBUTING.md) has details about contributing. All are welcome, but please be sure to check the [code of conduct](doc/CODE_OF_CONDUCT.md).
 - [`macOS_Development.md`](doc/macOS_Development.md) describes how to boostrap a macOS development environment.
+- [`winOS_Development.md`](doc/winOS_Development.md) describes how to boostrap a windows development environment.
 - [`doc/first_login.md`](doc/first_login.md) shows what you should do the first time you log in to the site.
 - [`doc/data_model.md`](doc/data_model.md) describes the security and data models.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,11 +10,9 @@ class ApplicationController < ActionController::Base
     game_control_root_path
   end
 
-
   def store_action
     return unless request.get?
-    if (request.path.end_with?("/sign_in") &&
-        !request.xhr?) # don't store ajax calls
+    if request.path.end_with?("/sign_in") && !request.xhr? # don't store ajax calls
       store_location_for(:admin, game_control_root_path)
     end
   end

--- a/app/controllers/game_control/admins_controller.rb
+++ b/app/controllers/game_control/admins_controller.rb
@@ -56,7 +56,7 @@ class GameControl::AdminsController < GameControlController
   end
 
   def cities
-    City.all.sort { |x, y| x.display_name <=> y.display_name }
+    City.all.sort { |x, y| x.full_display_name <=> y.full_display_name }
   end
 
   def create_params

--- a/app/controllers/game_control/cities_controller.rb
+++ b/app/controllers/game_control/cities_controller.rb
@@ -35,7 +35,7 @@ class GameControl::CitiesController < GameControlController
 
     if @city.update_attributes(city_params)
       redirect_to :game_control_cities,
-                  notice: "City <strong>#{@city.display_name}</strong> was successfully updated"
+                  notice: "City <strong>#{@city.full_display_name}</strong> was successfully updated"
     else
       generate_states
       generate_parents

--- a/app/controllers/game_control/cities_controller.rb
+++ b/app/controllers/game_control/cities_controller.rb
@@ -62,6 +62,6 @@ class GameControl::CitiesController < GameControlController
   end
 
   def city_params
-    params.require(:city).permit(:name, :state, :country, :parent_id)
+    params.require(:city).permit(:name, :display_name, :state, :country, :parent_id)
   end
 end

--- a/app/controllers/game_control/event_locations_controller.rb
+++ b/app/controllers/game_control/event_locations_controller.rb
@@ -55,7 +55,7 @@ class GameControl::EventLocationsController < GameControlController
   end
 
   def available_cities
-    all_cities = City.all.sort { |x, y| x.display_name <=> y.display_name }
+    all_cities = City.all.sort { |x, y| x.full_display_name <=> y.full_display_name }
     event_cities = @event.event_locations.map(&:city)
     all_cities - event_cities
   end

--- a/app/controllers/game_control/events_controller.rb
+++ b/app/controllers/game_control/events_controller.rb
@@ -60,6 +60,6 @@ class GameControl::EventsController < GameControlController
   end
 
   def build_locations
-    @event.event_locations.sort { |x, y| x.city.display_name <=> y.city.display_name }
+    @event.event_locations.sort { |x, y| x.city.full_display_name <=> y.city.full_display_name }
   end
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -19,7 +19,7 @@ class City < ActiveRecord::Base
     not child?
   end
 
-  def display_name
+  def full_display_name
     return "#{parent.name} - #{name}" if parent
     name
   end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -20,9 +20,13 @@ class City < ActiveRecord::Base
     not child?
   end
 
+  def parent_display_name
+    parent.display_name.present? ? parent.display_name : parent.name
+  end
+
   def full_display_name
     result = ''
-    result << (parent.display_name.present? ? parent.display_name : parent.name) + " - " + result if parent
+    result << parent_display_name + " - " + result if parent
     result << (display_name.present? ? display_name : name)
   end
 

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -20,7 +20,8 @@ class City < ActiveRecord::Base
   end
 
   def full_display_name
-    return "#{parent.name} - #{name}" if parent
-    name
+    result = ''
+    result << (parent.display_name.present? ? parent.display_name : parent.name) + " - " + result if parent
+    result << (display_name.present? ? display_name : name)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,7 +14,7 @@ class Event < ActiveRecord::Base
 
   def locations_tree
     locations = event_locations.includes(:city)
-    locations.to_a.sort! { |x, y| x.city.display_name <=> y.city.display_name }
+    locations.to_a.sort! { |x, y| x.city.full_display_name <=> y.city.full_display_name }
 
     build_tree locations
   end

--- a/app/views/event_locations/_location.json.jbuilder
+++ b/app/views/event_locations/_location.json.jbuilder
@@ -1,5 +1,5 @@
 if location.complete?
-  json.city location.city.name
+  json.city location.city.display_name.present? ? location.city.display_name : location.city.name
   json.bar location.bar_name
   json.bar_url location.bar_url
   json.start_time location.start_time.to_s(:time)

--- a/app/views/game_control/admins/_form.html.slim
+++ b/app/views/game_control/admins/_form.html.slim
@@ -29,7 +29,7 @@
                   = f.association :roles
             .col-sm-12.col-md-6
               .form-group
-                  = f.association :cities, collection: @cities, label_method: :display_name
+                  = f.association :cities, collection: @cities, label_method: :full_display_name
         .box-footer
           .pull-right
             =<> link_to 'Cancel', game_control_admins_path,

--- a/app/views/game_control/admins/index.html.slim
+++ b/app/views/game_control/admins/index.html.slim
@@ -28,7 +28,7 @@
                 tr
                   td = admin.email
                   td = admin.full_name
-                  td = admin.cities.map(&:display_name).join(',')
+                  td = admin.cities.map(&:full_display_name).join(',')
                   td = admin.roles.map(&:name).join(',')
                   td.text-right
                     .btn-group

--- a/app/views/game_control/cities/_form.html.slim
+++ b/app/views/game_control/cities/_form.html.slim
@@ -9,7 +9,7 @@
           .box-body
             = f.input :name, autofocus: true, placeholder: 'Stumptown'
             = f.input :parent_id, collection: parents,
-              label_method: :display_name,
+              label_method: :full_display_name,
               value_method: :id
             p.help-block
               | Either a parent or name is required.

--- a/app/views/game_control/cities/_form.html.slim
+++ b/app/views/game_control/cities/_form.html.slim
@@ -8,6 +8,9 @@
             | City Info
           .box-body
             = f.input :name, autofocus: true, placeholder: 'Stumptown'
+            = f.input :display_name, placeholder: 'Stumptown, OR'
+            p.help-block
+              | When present, this name is displayed to the user for disambiguation. For example “Paris, TX” versus “Paris, France”.
             = f.input :parent_id, collection: parents,
               label_method: :full_display_name,
               value_method: :id

--- a/app/views/game_control/cities/index.html.slim
+++ b/app/views/game_control/cities/index.html.slim
@@ -25,7 +25,7 @@
             tbody
               - @cities.each do |city|
                 tr
-                  td = city.display_name
+                  td = city.full_display_name
                   td = display_state(city.country, city.state)
                   td = city.country
                   td.text-right
@@ -45,8 +45,8 @@
                 - city.children.each do |child|
                   tr
                     td
-                      span data-toggle='tooltip' title="Child of #{city.display_name}"
-                        = child.display_name
+                      span data-toggle='tooltip' title="Child of #{city.full_display_name}"
+                        = child.full_display_name
                     td = child.state
                     td = child.country
                     td.text-right

--- a/app/views/game_control/event_locations/_form.html.slim
+++ b/app/views/game_control/event_locations/_form.html.slim
@@ -2,7 +2,7 @@
   .box-body
     = f.input :event_id, as: :hidden
     - unless @location.persisted?
-      = f.input :city_id, collection: @cities, label_method: :display_name
+      = f.input :city_id, collection: @cities, label_method: :full_display_name
     = f.input :bar_name
     = f.input :bar_url, as: :url
     = f.input :start_time, as: :time

--- a/app/views/game_control/event_locations/edit.html.slim
+++ b/app/views/game_control/event_locations/edit.html.slim
@@ -8,5 +8,5 @@
         .box-title
           i.fa.fa-calendar>
           | Edit
-          =< @location.city.display_name
+          =< @location.city.full_display_name
         = render "form"

--- a/app/views/game_control/events/_locations_table.html.slim
+++ b/app/views/game_control/events/_locations_table.html.slim
@@ -10,7 +10,7 @@
       - locations.each do |location|
         tr
           td
-            strong = location.city.display_name
+            strong = location.city.full_display_name
           td
             address
               - if location.bar_name.present?

--- a/app/views/game_control/events/new.html.slim
+++ b/app/views/game_control/events/new.html.slim
@@ -26,12 +26,12 @@
               - @cities.each do |city|
                 li
                   => check_box_tag 'city_ids[]', city.id, city.children.empty?, id: "city-#{city.id}"
-                  =< label_tag "city-#{city.id}", city.display_name
+                  =< label_tag "city-#{city.id}", city.full_display_name
                   - city.children.each do |child|
                     ul
                       li
                         => check_box_tag 'city_ids[]', child.id, true, id: "city-#{child.id}"
-                        =< label_tag "city-#{child.id}", child.display_name
+                        =< label_tag "city-#{child.id}", child.full_display_name
           .box-footer
             .pull-right
               =<> link_to 'Cancel', game_control_cities_path,

--- a/bin/winFixGems.bat
+++ b/bin/winFixGems.bat
@@ -1,0 +1,3 @@
+gem uninstall bcrypt
+gem uninstall bcrypt-ruby
+gem install bcrypt --platform=ruby

--- a/db/migrate/20170319230653_add_city_display_name.rb
+++ b/db/migrate/20170319230653_add_city_display_name.rb
@@ -1,0 +1,5 @@
+class AddCityDisplayName < ActiveRecord::Migration
+  def change
+    add_column :cities, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160201010708) do
+ActiveRecord::Schema.define(version: 20170319230653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,12 +64,13 @@ ActiveRecord::Schema.define(version: 20160201010708) do
   add_index "admins_roles", ["admin_id", "role_id"], name: "index_admins_roles_on_admin_id_and_role_id", using: :btree
 
   create_table "cities", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",         null: false
     t.string   "state"
-    t.string   "country",    null: false
+    t.string   "country",      null: false
     t.integer  "parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.string   "display_name"
   end
 
   add_index "cities", ["parent_id"], name: "index_cities_on_parent_id", using: :btree

--- a/doc/winOS_Development.md
+++ b/doc/winOS_Development.md
@@ -1,0 +1,31 @@
+# Overview
+
+This document will discuss how to resolve issues on a windows platform.
+It's not yet complete
+
+## Rails Install
+
+Instead of installing Ruby, it's best to use the full rails installer:
+
+http://railsinstaller.org/  Select Windows Ruby 2.3 
+
+## Getting the Code
+
+Clone the repository: `git clone https://github.com/PuzzledPint/puzzledpint.com.git` but note that your URL may be different if you’re a contributor with ssh access.
+
+...
+
+## Setting up the Database
+
+Add your windows username to postgres (with no password)
+...
+
+## Troubleshooting Gems
+
+- `./bin/WinFixGems.bat` will correct issues with some gems not being compiled.
+
+## Launch the Webapp
+
+- Open a browser to <http://localhost:3000> and look for the pintglass logo
+- Open a browser to <http://localhost:3000/game_control> and log in
+

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe City, type: :model do
     it { should validate_presence_of(:country) }
   end
 
-  describe '#display_name' do
+  describe '#full_display_name' do
     context 'has no parent' do
-      it 'returns city display_name' do
+      it 'returns city full_display_name' do
         city = build(:city)
-        expect(city.display_name).to eq city.name
+        expect(city.full_display_name).to eq city.name
       end
     end
 
     context 'has parent' do
-      it 'returns city display_name with parent' do
+      it 'returns city full_display_name with parent' do
         parent = build(:city)
         city = build(:city, parent: parent)
         expected_str = "#{parent.name} - #{city.name}"
-        expect(city.display_name).to eq expected_str
+        expect(city.full_display_name).to eq expected_str
       end
     end
   end

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -25,5 +25,21 @@ RSpec.describe City, type: :model do
         expect(city.full_display_name).to eq expected_str
       end
     end
+
+    context 'has no parent' do
+      it 'returns city full_display_name using display_name' do
+        city = build(:city, name: 'abc', display_name: 'def')
+        expect(city.full_display_name).to eq 'def'
+      end
+    end
+
+    context 'has parent' do
+      it 'returns city full_display_name with parent using display_name' do
+        parent = build(:city, name: 'abc', display_name: 'def')
+        city = build(:city, parent: parent, name: 'ghi', display_name: 'jkl')
+        expected_str = "def - jkl"
+        expect(city.full_display_name).to eq expected_str
+      end
+    end
   end
 end


### PR DESCRIPTION
Split into two commits. One renames the existing `display_name` function (which shows the city name prefixed by the parent's name, if available) to `full_display_name` to better indicate it's more of a breadcrumb thing. The other adds a display_name column to the database, which is used in place of “name,” if present, to better present disambiguation. For instance, Los Angeles is pretty indisputable, but Paris really needs to be qualified to Texas.