### PR TITLE
Correct (and simpler) way to validate bar URLs!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'inline_svg'
 
 gem 'analytics-ruby', '~> 2.0.0', require: 'segment/analytics'
 
+# For event location URL validation
+gem 'valid_url', '~> 0.0.4'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     analytics-ruby (2.0.13)
     arel (6.0.4)
     ast (2.3.0)
@@ -143,6 +145,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (2.0.5)
     puma (3.8.2)
     rack (1.6.5)
     rack-test (0.6.3)
@@ -267,6 +270,9 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.3)
     unicode_utils (1.4.0)
+    valid_url (0.0.4)
+      addressable
+      rails
     warden (1.2.7)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -318,6 +324,7 @@ DEPENDENCIES
   spring-commands-rspec
   tzinfo-data
   uglifier (>= 1.3.0)
+  valid_url (~> 0.0.4)
   web-console (~> 2.0)
 
 RUBY VERSION

--- a/app/models/event_location.rb
+++ b/app/models/event_location.rb
@@ -7,7 +7,7 @@ class EventLocation < ActiveRecord::Base
   validates :city, presence: true
   validates :event, presence: true
 
-  validates :bar_url, format: { with: /\A(https?\:\/\/)?/, message: "please enter a valid URL starting with http" }
+  validates :bar_url, url: true
 
   def complete?
     bar_name.present? && addr_street_1.present? && addr_city.present?


### PR DESCRIPTION
This should actually work now. Tested locally. Requires "valid_url" gem.
