### PR TITLE
Fix belongs_to :resource association on Role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,6 @@
 class Role < ApplicationRecord
   has_many :admins, through: :admins_roles
-  belongs_to :resource, polymorphic: true
+  belongs_to :resource, polymorphic: true, optional: true
 
   validates :resource_type,
             inclusion: { in: Rolify.resource_types },


### PR DESCRIPTION
Since Rails 5, all [belongs_to associations have an implicit presence validation][info], where before Rails 5 they were allowed to be `nil`.

Although this isn't a problem in production, where the roles have already been created, this made it impossible to create roles in a new development environment.

[info]: https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html