### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -153,7 +153,7 @@ Naming/FileName:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: false
   Exclude: []
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Description: Checks the indentation of the first parameter in a method call.
   Enabled: true
   EnforcedStyle: special_for_inner_method_call_in_parentheses
@@ -170,7 +170,7 @@ Style/For:
   - for
   - each
 Style/FrozenStringLiteralComment:
-  EnforcedStyle: when_needed
+  EnforcedStyle: always
   SupportedStyles:
     - when_needed
     - always
@@ -213,7 +213,7 @@ Layout/IndentationWidth:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
   Enabled: true
   Width: 2
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Description: Checks the indentation of the first key in a hash literal.
   Enabled: true
   EnforcedStyle: special_inside_parentheses
@@ -739,7 +739,7 @@ Style/IfWithSemicolon:
 Layout/IndentationConsistency:
   Description: Keep indentation straight.
   Enabled: true
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Description: Checks the indentation of the first element in an array literal.
   Enabled: true
 Style/InfiniteLoop:

--- a/lib/tasks/db_seed_user.rake
+++ b/lib/tasks/db_seed_user.rake
@@ -1,4 +1,3 @@
-
 namespace :db do
   namespace :seed do
     desc "create admin user"


### PR DESCRIPTION
Since a previous Rubocop upgrade the config has become out of date. This commit updates the names and values accordingly to apply the same code style as before.

![image](https://user-images.githubusercontent.com/4975/91747879-ea8e7000-ebb6-11ea-84da-c703066a998f.png)
